### PR TITLE
Fix critical timing bug

### DIFF
--- a/hebecon.c
+++ b/hebecon.c
@@ -64,7 +64,7 @@ int main( void ){
         PORTB |= 0x03u;
 
         delay_100us(14);
-        asm("nop");asm("nop");asm("nop");
+        asm("nop");asm("nop");asm("nop");asm("nop");
 
 
         if(PINB & 0x10u){


### PR DESCRIPTION
-Load bearing 'nop' instruction added.

Closes #3 